### PR TITLE
Match any two-letter country code, not just "en", and make the URL as such

### DIFF
--- a/src/wikimobilizer.js
+++ b/src/wikimobilizer.js
@@ -12,10 +12,10 @@ var Wikimobilizer = {
   },
 
   transformUrl: function(url) {
-    var regex = /http:\/\/en.wikipedia.org\/wiki\/([^\/]+)/;
+    var regex = /http:\/\/([a-z]{2}).wikipedia.org\/wiki\/([^\/]+)/;
     var match = url.match(regex);
     if (match) {
-      url = 'http://en.m.wikipedia.org/wiki/' + match[1];
+      url = 'http://' + match[1] + '.m.wikipedia.org/wiki/' + match[2];
     }
     return url;
   }


### PR DESCRIPTION
This changes the regex slightly to match a two-letter code (such as en, de, es, etc.) and then makes the redirect URL to match. Fixes https://github.com/hnrysmth/wikimobilizer/issues/1
