### PR TITLE
Rewrite all localizations and use secure URLs

### DIFF
--- a/src/wikimobilizer.js
+++ b/src/wikimobilizer.js
@@ -12,10 +12,10 @@ var Wikimobilizer = {
   },
 
   transformUrl: function(url) {
-    var regex = /https?:\/\/en.wikipedia.org\/wiki\/([^\/]+)/;
+    var regex = /https?:\/\/([a-z]{2}).wikipedia.org\/wiki\/([^\/]+)/;
     var match = url.match(regex);
     if (match) {
-      url = 'https://en.m.wikipedia.org/wiki/' + match[1];
+      url = 'https://' + match[1] + '.m.wikipedia.org/wiki/' + match[2];
     }
     return url;
   }

--- a/src/wikimobilizer.js
+++ b/src/wikimobilizer.js
@@ -12,10 +12,10 @@ var Wikimobilizer = {
   },
 
   transformUrl: function(url) {
-    var regex = /http:\/\/en.wikipedia.org\/wiki\/([^\/]+)/;
+    var regex = /https?:\/\/en.wikipedia.org\/wiki\/([^\/]+)/;
     var match = url.match(regex);
     if (match) {
-      url = 'http://en.m.wikipedia.org/wiki/' + match[1];
+      url = 'https://en.m.wikipedia.org/wiki/' + match[1];
     }
     return url;
   }

--- a/test/wikimobilizer.js
+++ b/test/wikimobilizer.js
@@ -11,13 +11,23 @@ describe('Wikimobilizer', function() {
     });
 
     it('rewrites Liverpool to the mobile Wikipedia site', function () {
-      Wikimobilizer.transformUrl('http://en.wikipedia.org/wiki/Liverpool').
-        should.equal('http://en.m.wikipedia.org/wiki/Liverpool');
+      Wikimobilizer.transformUrl('https://en.wikipedia.org/wiki/Liverpool').
+        should.equal('https://en.m.wikipedia.org/wiki/Liverpool');
     });
 
     it('rewrites a more complex URL to the mobile Wikipedia site', function () {
-      Wikimobilizer.transformUrl('http://en.wikipedia.org/wiki/Category:United_States_military_reconnaissance_aircraft_1950–1959').
-        should.equal('http://en.m.wikipedia.org/wiki/Category:United_States_military_reconnaissance_aircraft_1950–1959');
+      Wikimobilizer.transformUrl('https://en.wikipedia.org/wiki/Category:United_States_military_reconnaissance_aircraft_1950–1959').
+        should.equal('https://en.m.wikipedia.org/wiki/Category:United_States_military_reconnaissance_aircraft_1950–1959');
+    });
+
+    it('rewrites the German Wikipedia article about Ireland to the mobile Wikipedia site', function () {
+      Wikimobilizer.transformUrl('https://de.wikipedia.org/wiki/Irland').
+        should.equal('https://de.m.wikipedia.org/wiki/Irland');
+    });
+
+    it('rewrites non-secure URLs to their secure mobile variant', function () {
+      Wikimobilizer.transformUrl('http://de.wikipedia.org/wiki/Irland').
+        should.equal('https://de.m.wikipedia.org/wiki/Irland');
     });
 
   });


### PR DESCRIPTION
This PR lets the transform function rewrite all Wikipedia localizations and uses the secure (`https`) URL variant. Relevant tests are included and existing tests have been updated to use `https` URLs.