### PR TITLE
Firefox support

### DIFF
--- a/src/wikimobilizer.js
+++ b/src/wikimobilizer.js
@@ -1,14 +1,18 @@
 var Wikimobilizer = {
-
   listen: function(event) {
     var filter = { urls : ["<all_urls>"] };
     event.addListener(this.redirect.bind(this), filter, ["blocking"]);
   },
 
   redirect: function(details) {
-    return {
-      redirectUrl: this.transformUrl(details.url)
-    };
+    var redirectUrl = this.transformUrl(details.url);
+    if (redirectUrl !== details.url) {
+      return {
+        redirectUrl: redirectUrl
+      };
+    } else {
+      return {};
+    }
   },
 
   transformUrl: function(url) {
@@ -22,7 +26,9 @@ var Wikimobilizer = {
 
 };
 
-if (typeof chrome !== 'undefined' && typeof chrome.webRequest !== 'undefined') {
+if (typeof browser !== "undefined" && typeof browser.webRequest !== 'undefined') {
+  Wikimobilizer.listen(browser.webRequest.onBeforeRequest);
+} else if (typeof chrome !== "undefined" && typeof chrome.webRequest !== 'undefined') {
   Wikimobilizer.listen(chrome.webRequest.onBeforeRequest);
 } else if (typeof module !== 'undefined') {
   module.exports = Wikimobilizer;;

--- a/test/wikimobilizer.js
+++ b/test/wikimobilizer.js
@@ -32,5 +32,12 @@ describe('Wikimobilizer', function() {
 
   });
 
+  describe("#redirect", function() {
+    it('does only issue a redirect if the requested URL requires one', function () {
+      Wikimobilizer.redirect({url: "https://de.m.wikipedia.org/wiki/Irland"}).
+        should.be.an.Object.and.be.empty;
+    });
+  });
+
 });
 


### PR DESCRIPTION
Hey Henry. I recently switched to Firefox (again) as it's finally fast again with version 57, now I am missing some of my favorite Chrome extensions. So here is a PR for Firefox support. Changes made:

- Chrome's `chrome` object is called `browser` in Firefox, so both are checked as targets for registering the listener.
- `redirect` only issues a redirect if the URL has changed. Firefox will go into infinite loop otherwise, while Chrome seems to ignore a redirect to the same URL.
- Test for the change in the redirect method was added.

If you want to test this in Firefox, go to `about:debugging` and load the extension from its `manifest.json` file.

All the best,
Vincent